### PR TITLE
modules: fix: version 2.0.0 is not installable via go-tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ and KDE's 'kmimetypefinder' in performance
 
 The library:
 ```bash
-go get github.com/zRedShift/mimemagic
+go get github.com/zRedShift/mimemagic/v2
 ```
 The CLI:
 ```bash
-go get github.com/zRedShift/mimemagic/cmd/mimemagic
+go get github.com/zRedShift/mimemagic/v2/cmd/mimemagic
 ```
 
 ## API
@@ -57,7 +57,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/zRedShift/mimemagic"
+	"github.com/zRedShift/mimemagic/v2"
 	"strings"
 )
 

--- a/cmd/mimemagic/main.go
+++ b/cmd/mimemagic/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/zRedShift/mimemagic"
 	"os"
 	"path/filepath"
+
+	"github.com/zRedShift/mimemagic/v2"
 )
 
 var (

--- a/doc.go
+++ b/doc.go
@@ -7,10 +7,10 @@ To generate your own database simply remove the leading space, point to the
 directory with freedesktop.org package files (freedesktop.org.xml, if it
 exists, is always processed first and Override.xml is always processed last),
 and run go generate:
-  go:generate go run github.com/zRedShift/mimemagic/cmd/parser /usr/share/mime/packages
+  go:generate go run github.com/zRedShift/mimemagic/v2/cmd/parser /usr/share/mime/packages
 
 To use the default freedesktop.org.xml file provided in this package:
-  go:generate go run github.com/zRedShift/mimemagic/cmd/parser cmd/parser
+  go:generate go run github.com/zRedShift/mimemagic/v2/cmd/parser cmd/parser
 
 globs.go is generated unformatted so it's a good idea to run this for your OCD
   go:generate go fmt globs.go

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,6 @@
-module github.com/zRedShift/mimemagic
+module github.com/zRedShift/mimemagic/v2
 
 go 1.16
-
-// license incompatible
-retract v1.0.0
-
-retract v1.0.1
-
-retract v1.0.2
-
-retract v1.1.0
-
-retract v1.1.1
 
 require (
 	golang.org/x/net v0.0.0-20181017193950-04a2e542c03f


### PR DESCRIPTION
A git tag and github release was created for a version 2.0.0 but the
version was not installable via go tools and could not be added as
dependency to a go.mod file.

For Major version >1 the version must be appended to the import path.
This was missing. (see
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher
for more information)

Append /v2 to the import path, change all references accordingly.
The retract directives for minor versions of v1 are removed. They can
only be defined in the go.mod file for the same major version.